### PR TITLE
Allow events to expand past their range

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "./dist/react-big-calendar.js": {
-    "bundled": 737271,
-    "minified": 197274,
-    "gzipped": 60401
+    "bundled": 1156300,
+    "minified": 260271,
+    "gzipped": 81515
   },
   "./dist/react-big-calendar.min.js": {
-    "bundled": 663666,
-    "minified": 174905,
-    "gzipped": 54412
+    "bundled": 1082695,
+    "minified": 237902,
+    "gzipped": 75480
   },
   "dist/react-big-calendar.esm.js": {
-    "bundled": 239158,
-    "minified": 106481,
-    "gzipped": 26881,
+    "bundled": 250595,
+    "minified": 110075,
+    "gzipped": 27917,
     "treeshaked": {
       "rollup": {
-        "code": 67950,
-        "import_statements": 1498
+        "code": 71484,
+        "import_statements": 1523
       },
       "webpack": {
-        "code": 71475
+        "code": 75014
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbc-fork-react-big-calendar",
-  "version": "0.33.70",
+  "version": "0.33.71",
   "description": "Calendar! with events",
   "author": {
     "name": "Jason Quense",


### PR DESCRIPTION
These updates allow events to expand to fill the rest of the available width in their row :rocket:

Before:
<img width="607" alt="Screenshot 2025-01-28 at 2 26 25 PM" src="https://github.com/user-attachments/assets/9dd1aae4-be25-4156-9dba-aa9942316209" />

After:
<img width="764" alt="Screenshot 2025-01-28 at 2 26 09 PM" src="https://github.com/user-attachments/assets/6e0417b3-53a8-468b-a136-999c6f8a266f" />
