### PR TITLE
Prevent events from spilling across weeks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ node_modules
 # Sometimes we pack the module locally for testing
 *.tgz
 .claude
+
+# Personal settings
+.vscode/*

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,26 +24,26 @@
     }
   },
   "react-big-calendar.js": {
-    "bundled": 2198758,
-    "minified": 528691,
-    "gzipped": 165597
+    "bundled": 2198298,
+    "minified": 528486,
+    "gzipped": 165520
   },
   "react-big-calendar.min.js": {
-    "bundled": 368164,
-    "minified": 367238,
-    "gzipped": 118141
+    "bundled": 368145,
+    "minified": 367219,
+    "gzipped": 118135
   },
   "react-big-calendar.esm.js": {
-    "bundled": 241510,
-    "minified": 108109,
-    "gzipped": 28325,
+    "bundled": 241695,
+    "minified": 108266,
+    "gzipped": 28371,
     "treeshaked": {
       "rollup": {
-        "code": 78713,
+        "code": 78750,
         "import_statements": 1798
       },
       "webpack": {
-        "code": 82476
+        "code": 82513
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -24,26 +24,26 @@
     }
   },
   "react-big-calendar.js": {
-    "bundled": 2198298,
-    "minified": 528486,
+    "bundled": 2198294,
+    "minified": 528484,
     "gzipped": 165520
   },
   "react-big-calendar.min.js": {
-    "bundled": 368145,
-    "minified": 367219,
-    "gzipped": 118135
+    "bundled": 368440,
+    "minified": 367253,
+    "gzipped": 118146
   },
   "react-big-calendar.esm.js": {
-    "bundled": 241695,
-    "minified": 108266,
-    "gzipped": 28371,
+    "bundled": 241626,
+    "minified": 108207,
+    "gzipped": 28373,
     "treeshaked": {
       "rollup": {
-        "code": 78750,
+        "code": 78748,
         "import_statements": 1798
       },
       "webpack": {
-        "code": 82513
+        "code": 82511
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rbc-fork-react-big-calendar",
-  "version": "0.40.52",
+  "version": "0.40.53",
   "description": "Calendar! with events",
   "author": {
     "name": "Jason Quense",

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -124,7 +124,7 @@ export default class TimeGrid extends Component {
     const groupedBackgroundEvents = resources.groupEvents(backgroundEvents)
 
     return resources.map(([id, resource], i) =>
-      range.map((date, jj) => {
+      range.map((date) => {
         let daysEvents = (groupedEvents.get(id) || []).filter((event) =>
           localizer.inRange(
             date,
@@ -154,7 +154,7 @@ export default class TimeGrid extends Component {
             resource={resource && id}
             components={components}
             isNow={localizer.isSameDate(date, now)}
-            key={i + '-' + jj}
+            key={i + '-' + +date}
             date={date}
             events={daysEvents}
             backgroundEvents={daysBackgroundEvents}


### PR DESCRIPTION
By including the key in the date, the thought is that React shouldn't reuse the day columns when switching weeks, meaning there should be no opportunity for children to bleed over from one week to another.

The repo we forked off of also includes the date in their key, so this should be a safe change to make.
https://github.com/bigcalendar/react-big-calendar/blob/183783ad45c8b845c2f57c46711c1c4c85047843/src/TimeGrid.js#L168-L181